### PR TITLE
[DR-1601] Prevent to remove current builds in the project path

### DIFF
--- a/cdn-uploader.js
+++ b/cdn-uploader.js
@@ -18,7 +18,6 @@ function UploadFilesFromPath(config) {
 			await client.useDefaultSettings();
 			console.log(`[+] Starting to upload the content of "${config.sourcePath}".`);
 			await client.ensureDir(`/${config.cpCode}/${config.projectName}`);
-			await client.clearWorkingDir();
 			await client.uploadDir(config.sourcePath, config.versionName);
 			console.log(`[+] Folder "${config.sourcePath}" uploaded.`);
 			client.close();


### PR DESCRIPTION
## Background
  
Currently in each upload of a new build to the cdn the previous builds in the project path in CDN are being deleted.
  
## Changes done
  
Remove clear path instruction
  
## Pending to be done
  
N/A
  
## Notes
  
It's not needed to delete each folder level of the path to upload the builds because each one will have a new build number then never will be overwritted.
 
## Demo

Expected behavior with pr changes:

![image](https://user-images.githubusercontent.com/7245667/39013394-a73f5c7e-43ed-11e8-9af5-a67b5f20f135.png)
